### PR TITLE
Return null when temperature/humidity value is out of range

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following features are unsupported since I don't have the required hardware:
 * Register reads may randomly fail some time after the controller has been restarted, especially before all the 
   thermostats have properly registered themselves
 * A thermostat may sometimes start reporting temperature and humidity as being 6,453.6 C and 3,276.8%. The cause of 
-  this is unknown at this point
+  this is unknown at this point. When such values are encountered, `null` is used as the sensor state value.
 
 ## Installation
 

--- a/src/modbus.ts
+++ b/src/modbus.ts
@@ -49,8 +49,8 @@ type RuntimeDeviceInformation = {
 
 export type ZoneValues = {
   isHeating: boolean
-  currentTemperature: number
-  humidity: number
+  currentTemperature: number | null
+  humidity: number | null
   setTemperature: number
   batteryLevel: number
 }
@@ -136,7 +136,7 @@ export const getValues = async (modbusClient: ModbusRTU): Promise<Values> => {
     const isHeating = Boolean(zoneHeatingResult.data[0] & (1 << i))
     const currentTemperature = parseTemperature(zoneCurrentTemperatureResult.data[i])
     const humidity = parseHumidity(zoneHumidityResults.data[i])
-    const setTemperature = parseTemperature(zoneSetTemperatureResult.data[i])
+    const setTemperature = parseTemperature(zoneSetTemperatureResult.data[i]) as number
     const batteryLevel = zoneBatteryLevelResult.data[i]
 
     zones.push({

--- a/src/roth.ts
+++ b/src/roth.ts
@@ -17,8 +17,11 @@ export const parseSerialNumber = (high: number, low: number): string => {
   return String(`${high}${low}`)
 }
 
-export const parseTemperature = (value: number): number => {
-  return value / 10
+export const parseTemperature = (value: number): number | null => {
+  const scaledValue = value / 10
+
+  // Use null if value is invalid (temperature and humidity can sometimes get reported using maximum values)
+  return scaledValue > 1000 ? null : scaledValue
 }
 
 export const parseHumidity = parseTemperature


### PR DESCRIPTION
Should make the value in Home Assistant be "unknown" which won't mess up graphs

Related to https://github.com/Jalle19/roth-modbus-mqtt/issues/2